### PR TITLE
Debug: GroupAddEvent&Request

### DIFF
--- a/src/main/kotlin/org/itxtech/mirainative/bridge/MiraiBridge.kt
+++ b/src/main/kotlin/org/itxtech/mirainative/bridge/MiraiBridge.kt
@@ -39,6 +39,7 @@ import kotlinx.io.core.*
 import net.mamoe.mirai.contact.Member
 import net.mamoe.mirai.contact.MemberPermission
 import net.mamoe.mirai.event.events.MemberJoinRequestEvent
+import net.mamoe.mirai.event.events.BotInvitedJoinGroupRequestEvent
 import net.mamoe.mirai.event.events.NewFriendRequestEvent
 import net.mamoe.mirai.getFriendOrNull
 import net.mamoe.mirai.getGroupOrNull
@@ -257,13 +258,22 @@ object MiraiBridge {
     fun setGroupAddRequest(pluginId: Int, requestId: String, reqType: Int, type: Int, reason: String) =
         call(pluginId, 0) {
             MiraiNative.nativeLaunch {
-                (CacheManager.getEvent(requestId) as? MemberJoinRequestEvent)?.apply {
-                    when (type) {//1通过，2拒绝，3忽略
-                        1 -> accept()
-                        2 -> reject()
-                        3 -> ignore()
-                    }
-                }
+				if(reqType == Bridge.REQUEST_GROUP_APPLY) {
+					(CacheManager.getEvent(requestId) as? MemberJoinRequestEvent)?.apply {
+						when (type) {//1通过，2拒绝，3忽略
+							1 -> accept()
+							2 -> reject()
+							3 -> ignore()
+						}
+					}
+				} else {
+					(CacheManager.getEvent(requestId) as? BotInvitedJoinGroupRequestEvent)?.apply {
+						when (type) {//1通过，2忽略
+							1 -> accept()
+							2 -> ignore()
+						}
+					}
+				}
             }
             return 0
         }

--- a/src/main/kotlin/org/itxtech/mirainative/manager/EventManager.kt
+++ b/src/main/kotlin/org/itxtech/mirainative/manager/EventManager.kt
@@ -129,11 +129,22 @@ object EventManager {
                 )
             }
         }
-        MiraiNative.subscribeAlways<MemberJoinRequestEvent> { ev ->
+		
+		
+		MiraiNative.subscribeAlways<MemberJoinRequestEvent> { ev ->
+            MiraiNative.nativeLaunch {
+                NativeBridge.eventRequestAddGroup(
+                    Bridge.REQUEST_GROUP_APPLY,
+                    getTimestamp(), groupId, fromId, message, CacheManager.cacheEvent(ev)
+                )
+            }
+        }
+		
+        MiraiNative.subscribeAlways<BotInvitedJoinGroupRequestEvent> { ev ->
             MiraiNative.nativeLaunch {
                 NativeBridge.eventRequestAddGroup(
                     Bridge.REQUEST_GROUP_INVITED,
-                    getTimestamp(), groupId, fromId, message, CacheManager.cacheEvent(ev)
+                    getTimestamp(), groupId, invitorId, "", CacheManager.cacheEvent(ev)
                 )
             }
         }


### PR DESCRIPTION
当前的MiraiNative对于群事件的处理是错误的，群员加群被当成了机器人被邀请来处理，而机器人被邀请则没有做处理，而对于邀请/加群通过事件的处理也同样错误
此PR修复了这个问题